### PR TITLE
PieChart - Responsive Mobile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "plugin:prettier/recommended"]
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 120,
+  "quoteProps": "as-needed",
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
   "printWidth": 120,
   "quoteProps": "as-needed",
   "singleQuote": true,
+  "jsxSingleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
   "useTabs": false,

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,11 +2,11 @@
   "arrowParens": "always",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "jsxSingleQuote": false,
   "printWidth": 120,
   "quoteProps": "as-needed",
-  "singleQuote": false,
+  "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "useTabs": false
+  "useTabs": false,
+  "semi": false
 }

--- a/components/pieChart.js
+++ b/components/pieChart.js
@@ -1,89 +1,89 @@
 // treasury-frontend/pages/components/PieChart.js
 import * as d3 from 'd3'
 import { useEffect, useRef, useState } from 'react'
-import formatToDollar from '../utils/helpers'
+import formatToDollar from '@/utils/helpers'
+import styles from './pieChart.module.scss'
 
 const PieChart = () => {
-  const ref = useRef();
-  const [data, setData] = useState(null);
-  const [legendData, setLegendData] = useState([]);
-  const colorScale = d3.scaleOrdinal(d3.schemeCategory10);
+  const ref = useRef()
+  const [data, setData] = useState(null)
+  const [legendData, setLegendData] = useState([])
+  const colorScale = d3.scaleOrdinal(d3.schemeCategory10)
 
   useEffect(() => {
     fetch('/api/data?file=sums.csv&type=summary')
-      .then(response => response.json())
-      .then(data => {
+      .then((response) => response.json())
+      .then((data) => {
         setData(data)
         setLegendData(Object.keys(data))
       })
-      .catch(error => console.error('Error:', error));
-  }, []);
+      .catch((error) => console.error('Error:', error))
+  }, [])
 
   useEffect(() => {
     if (data && Object.keys(data).length > 0) {
-      const svg = d3.select(ref.current);
-      const width = svg.node().getBoundingClientRect().width;
-      const height = svg.node().getBoundingClientRect().height;
-      const radius = Math.min(width, height) * 0.8 / 2;
+      const svg = d3.select(ref.current)
+      const width = svg.node().getBoundingClientRect().width
+      const height = svg.node().getBoundingClientRect().height
+      const radius = (Math.min(width, height) * 0.8) / 2
 
       // const colorScale = d3.scaleOrdinal(d3.schemeCategory10);
-      const tooltip = d3.select("body").append("div")
-        .attr("class", "tooltip")
-        .style("opacity", 0);
+      const tooltip = d3.select('body').append('div').attr('class', 'tooltip').style('opacity', 0)
 
-      svg.attr('viewBox', [-width / 2, -height / 2, width, height]);
+      svg.attr('viewBox', [-width / 2, -height / 2, width, height])
 
-      const pie = d3.pie().value(d => d[1])(Object.entries(data));
+      const pie = d3.pie().value((d) => d[1])(Object.entries(data))
 
-      const arc = d3.arc()
-        .innerRadius(0)
-        .outerRadius(radius)
+      const arc = d3.arc().innerRadius(0).outerRadius(radius)
 
       svg
-      .selectAll('path')
-      .data(pie)
-      .join('path')
-      .attr('d', arc)
-      .attr('fill', (d,i) => colorScale(i))
-      .on('mouseover', (event, d) => {
-        tooltip.transition()
-          .duration(200)
-          .style("opacity", .9);
-        tooltip.html(`${d.data[0]}: ${formatToDollar(d.data[1])}`)
-          .style("left", (event.pageX) + "px")
-          .style("top", (event.pageY - 28) + "px");
-      })
-      .on('mouseout', (d) => {
-        tooltip.transition()
-          .duration(500)
-          .style("opacity", 0);
-      });
+        .selectAll('path')
+        .data(pie)
+        .join('path')
+        .attr('d', arc)
+        .attr('fill', (d, i) => colorScale(i))
+        .on('mouseover', (event, d) => {
+          tooltip.transition().duration(200).style('opacity', 0.9)
+          tooltip
+            .html(`${d.data[0]}: ${formatToDollar(d.data[1])}`)
+            .style('left', event.pageX + 'px')
+            .style('top', event.pageY - 28 + 'px')
+        })
+        .on('mouseout', (d) => {
+          tooltip.transition().duration(500).style('opacity', 0)
+        })
     }
-  }, [data]);
-
-
+  }, [data])
 
   if (!data) return <p>Loading...</p>
   return (
-    <div className="flex flex-col items-start border rounded-lg py-8 px-4 ml-4">
+    <div className={styles.container}>
+      <div className="flex justify-center font-bold text-white w-full">
+        {`Total Treasury: ${formatToDollar(Object.values(data).reduce((a, b) => a + b, 0))}`}
+      </div>
+      <div className={`flex flex-col md:flex-row justify-center items-center px-4`}>
+        <svg ref={ref} className={styles.chart} />
+        <div className={styles.legend}>
+          {legendData.map((key, i) => (
+            <div key={key} className={styles.legendItem}>
+              <div
+                style={{
+                  width: '18px',
+                  height: '18px',
+                  backgroundColor: colorScale(i),
+                }}
+              ></div>
+              <span className="ml-2 mr-2 text-white">{key}</span>
+            </div>
+          ))}
+        </div>
+      </div>
 
-    <div className="flex flex-row justify-center items-center">
-      <svg className="w-1/4 py-4 ml-8" style={{ height: `${legendData.length * 28}px` }}>
-        {legendData.map((key, i) => (
-          <g key={key} transform={`translate(0,${i * 20})`}>
-            <rect x={0} width={18} height={18} fill={colorScale(i)} />
-            <text x={24} y={9} dy=".35em" fill="white">{key}</text>
-          </g>
-        ))}
-      </svg>
-      <svg ref={ref} className=""/>
+      <div className="flex items-center justify-center py-4 w-full">
+        <span className={styles.badge}>Last Updated 10-22-2023</span>
+      </div>
     </div>
-
-    <div className="p-8 font-bold text-white">
-      {`Total Treasury: ${formatToDollar(Object.values(data).reduce((a, b) => a + b, 0))}`}
-    </div>
-    </div>
-  );
+  )
 }
 
 export default PieChart

--- a/components/pieChart.js
+++ b/components/pieChart.js
@@ -58,7 +58,7 @@ const PieChart = () => {
   if (!data) return <p>Loading...</p>
   return (
     <div className={styles.container}>
-      <div className="flex justify-center font-bold text-white w-full">
+      <div className='flex justify-center font-bold text-white w-full'>
         {`Total Treasury: ${formatToDollar(Object.values(data).reduce((a, b) => a + b, 0))}`}
       </div>
       <div className={`flex flex-col md:flex-row justify-center items-center px-4`}>
@@ -73,14 +73,10 @@ const PieChart = () => {
                   backgroundColor: colorScale(i),
                 }}
               ></div>
-              <span className="ml-2 mr-2 text-white">{key}</span>
+              <span className='ml-2 mr-2 text-white'>{key}</span>
             </div>
           ))}
         </div>
-      </div>
-
-      <div className="flex items-center justify-center py-4 w-full">
-        <span className={styles.badge}>Last Updated 10-22-2023</span>
       </div>
     </div>
   )

--- a/components/pieChart.module.scss
+++ b/components/pieChart.module.scss
@@ -5,7 +5,7 @@
   align-items: center;
   border: 1px solid white;
   border-radius: 0.5rem;
-  padding-top: 16px;
+  padding: 16px;
 }
 
 .legend {
@@ -26,17 +26,6 @@
   align-items: center;
   justify-content: start;
   min-width: 120px;
-}
-
-.badge {
-  width: fit-content;
-  background: white;
-  color: black;
-  font-size: 0.75rem;
-  font-weight: 400;
-  border-width: 1px;
-  border-radius: 0.5rem;
-  padding: 0 4px;
 }
 
 .totalTreasury {

--- a/components/pieChart.module.scss
+++ b/components/pieChart.module.scss
@@ -1,0 +1,48 @@
+.container {
+  // relative flex flex-col items-start border rounded-lg py-4
+  position: relative;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  border: 1px solid white;
+  border-radius: 0.5rem;
+  padding-top: 16px;
+}
+
+.legend {
+  display: flex;
+  flex-flow: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 500px;
+}
+
+.chart {
+  width: 300px;
+  height: 300px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+  min-width: 120px;
+}
+
+.badge {
+  width: fit-content;
+  background: white;
+  color: black;
+  font-size: 0.75rem;
+  font-weight: 400;
+  border-width: 1px;
+  border-radius: 0.5rem;
+  padding: 0 4px;
+}
+
+.totalTreasury {
+  margin-top: 8px;
+  font-weight: 700;
+  color: white;
+  text-align: center;
+}

--- a/components/pieChart.module.scss
+++ b/components/pieChart.module.scss
@@ -1,5 +1,4 @@
 .container {
-  // relative flex flex-col items-start border rounded-lg py-4
   position: relative;
   display: flex;
   flex-flow: column;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.11.0"
+    "react-icons": "^4.11.0",
+    "sass": "^1.69.5"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -28,6 +29,7 @@
     "eslint": "^8",
     "eslint-config-next": "13.5.6",
     "postcss": "^8",
+    "prettier": "^3.0.3",
     "tailwindcss": "^3",
     "typescript": "^5"
   }

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -1,0 +1,10 @@
+.badge {
+  width: fit-content;
+  background: white;
+  color: black;
+  font-size: 0.75rem;
+  font-weight: 400;
+  border-width: 1px;
+  border-radius: 0.5rem;
+  padding: 0 4px;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import PieChart from '../../components/pieChart.js'
 import dynamic from 'next/dynamic'
 import { ApolloProvider } from '@apollo/client'
 import client from '../../utils/apollo-client'
+import styles from './page.module.scss'
 
 export default function Home() {
   return (
@@ -15,11 +16,14 @@ export default function Home() {
       <ApolloProvider client={client}>
         <main className='flex min-h-screen flex-col items-center justify-between p-6 md:p-24'>
           <h1 className='text-xl md:text-4xl font-bold font-inter text-white'>Synapse Treasury Holdings</h1>
+          <div className='flex items-center justify-center py-4 w-full'>
+            <span className={styles.badge}>Last Updated 10-22-2023</span>
+          </div>
           <div className='w-full md:w-2/3 h-full py-8'>
             <PieChart />
           </div>
-          <div className='flex justify-between w-2/3 mx-auto'>
-            <div className='flex-1 border border-white p-4 rounded-lg mr-2'>
+          <div className='flex flex-col sm:flex-row justify-between w-full sm:w-3/3 '>
+            <div className='flex-1 border border-white p-4 rounded-lg'>
               <ChainHoldings />
             </div>
             <div className='flex-1 border border-white rounded-lg p-4 ml-2'>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,42 +1,38 @@
-"use client"
+'use client'
 import Image from 'next/image'
-import React from 'react';
+import React from 'react'
 import ChainHoldings from '../../components/chainHoldings.js'
 import TokenList from '../../components/tokenList.js'
 import MonthList from '../../components/pastHoldings.js'
 import PieChart from '../../components/pieChart.js'
-import dynamic from 'next/dynamic';
-import { ApolloProvider } from '@apollo/client';
-import client from '../../utils/apollo-client';
+import dynamic from 'next/dynamic'
+import { ApolloProvider } from '@apollo/client'
+import client from '../../utils/apollo-client'
 
 export default function Home() {
   return (
     <div className='bg-black'>
-    <ApolloProvider client={client}>
-    <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1 className="text-4xl font-bold font-inter text-white">Synapse Treasury Holdings</h1>
-      <div className= "w-2/3 h-full py-4">
-        <h3 className="font-bold font-inter text-white">Last Updated 10-22-2023</h3>
-        <PieChart/> 
-      </div>
-      <div className="flex justify-between w-2/3 mx-auto">
-        <div className="flex-1 border border-white p-4 rounded-lg mr-2">
-          <ChainHoldings/>
-          
-        </div>
-        <div className="flex-1 border border-white rounded-lg p-4 ml-2">
-          <TokenList />
-        </div>
-      </div>
-      <h3 className="font-bold font-inter py-4 text-white">Historical Data</h3>
-      <div className= "w-2/3 h-full p-8 border rounded-lg">
-      
-        <MonthList/>
-      </div>
+      <ApolloProvider client={client}>
+        <main className='flex min-h-screen flex-col items-center justify-between p-6 md:p-24'>
+          <h1 className='text-xl md:text-4xl font-bold font-inter text-white'>Synapse Treasury Holdings</h1>
+          <div className='w-full md:w-2/3 h-full py-8'>
+            <PieChart />
+          </div>
+          <div className='flex justify-between w-2/3 mx-auto'>
+            <div className='flex-1 border border-white p-4 rounded-lg mr-2'>
+              <ChainHoldings />
+            </div>
+            <div className='flex-1 border border-white rounded-lg p-4 ml-2'>
+              <TokenList />
+            </div>
+          </div>
+          <h3 className='font-bold font-inter py-4 text-white'>Historical Data</h3>
+          <div className='w-2/3 h-full p-8 border rounded-lg'>
+            <MonthList />
+          </div>
 
-      <div className="relative flex place-items-center before:absolute before:h-[300px] before:w-[480px] before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px] z-[-1]">
-      
-        {/* <Image
+          <div className="relative flex place-items-center before:absolute before:h-[300px] before:w-[480px] before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-[240px] after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 before:lg:h-[360px] z-[-1]">
+            {/* <Image
           className="relative dark:drop-shadow-[0_0_0.3rem_#ffffff70] dark:invert"
           src="/next.svg"
           alt="Next.js Logo"
@@ -44,17 +40,20 @@ export default function Home() {
           height={37}
           priority
         /> */}
-      </div>
-
-
-    </main>
-    <div className="w-1/8 flex justify-center items-center bg-black ">
-      <a href="https://github.com/Defi-Moses/synapse-treasury/blob/main/README.md#methodology" target="_blank" rel="noopener noreferrer" className="text-white">
-        Methodology can be found 
-        <span className="text-blue-500"> here</span>
-      </a>
-    </div>
-    </ApolloProvider>
+          </div>
+        </main>
+        <div className='w-1/8 flex justify-center items-center bg-black '>
+          <a
+            href='https://github.com/Defi-Moses/synapse-treasury/blob/main/README.md#methodology'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-white'
+          >
+            Methodology can be found
+            <span className='text-blue-500'> here</span>
+          </a>
+        </div>
+      </ApolloProvider>
     </div>
   )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,7 +602,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^3.5.3:
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1658,6 +1658,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immutable@^4.0.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.4.tgz#2e07b33837b4bb7662f288c244d1ced1ef65a78f"
+  integrity sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -2338,6 +2343,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
+
 prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -2513,6 +2523,15 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@^1.69.5:
+  version "1.69.5"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.5.tgz#23e18d1c757a35f2e52cc81871060b9ad653dfde"
+  integrity sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -2577,7 +2596,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
Since this PR is the very beginning of our collaboration, i would like to thank you for the opportunity of getting involved!

Some things addressed in this PR:

- [x] Added Prettier and .prettierrc config file to the repo, so we can both write code following the same style. I have tried to add in some basic rules that most likely followed your existing style. If you see some things have jumped around, added/removed space or brackets, it's doing that automatically thanks for the .prettierrc file!
- [x] Added dynamic imports for everything via '@/' - previously it was only doing it for app folder
- [x] Changed from svg to HTML for the creation of the pie chart legend items, as it is kind of standard and much easier to work with when we talk about web page responsiveness across screensizes.
- [x] Added optional SASS support. Since we're heavily using D3 with Tailwind, D3 tends to create its styles after JIT(Just In Time) of Tailwind kicks in, and we simply can't do anything about that but write CSS in a separate file. I tried to write as much Tailwind myself as i quite like it.

The main thing addressed in this PR:
- [x] Create a responsive & clean view for the PieChart for Mobile. 

Notes:
- Keeping as much as i possibly can from the original looks until i've got everything displaying correctly across all screen sizes. After we're done with that, we can discuss/apply some 2023 look to it! There will be a separate, bigger PR at some point that addresses various Design Theory elements, consistency etc.

Before:
![Screenshot 2023-10-30 at 18 08 09](https://github.com/Defi-Moses/synapse-treasury-frontend/assets/20832842/91c1119f-6c7a-4096-84e9-04a5eadd275e)

After:
![Screenshot 2023-10-30 at 18 02 58](https://github.com/Defi-Moses/synapse-treasury-frontend/assets/20832842/3979fb10-204a-4fa0-8513-89aff194490e)
